### PR TITLE
Make error message throws correctly on node<=0.12.x

### DIFF
--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -6,11 +6,11 @@ import semver from 'semver';
 if (semver.lt(process.version, '4.0.0')) {
   const babelLatest = 'babel-polyfill';
   const babelPrev = 'babel/polyfill';
-
-  const isBabelLatest = require.resolve(babelLatest);
-  const isBabelPrev = require.resolve(babelPrev);
-
-  if (!isBabelLatest && !isBabelPrev) {
+  let isBabelLatest = false;
+  try {
+    isBabelLatest = require.resolve(babelLatest);
+    require.resolve(babelPrev);
+  } catch (e) {
     throw new Error(`
       For Node <= v0.12.x Babel polyfill is required.
       Make sure it's installed in your 'node_modules/' directory.


### PR DESCRIPTION
I found the ```require.resolve``` will throws error when target module not found, so use ```try catch``` to make the error message for ```node<=0.12.x``` can throw correctly.