### PR TITLE
Avoid multiple babel-polyfill loaded

### DIFF
--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -16,11 +16,12 @@ if (semver.lt(process.version, '4.0.0')) {
       Make sure it's installed in your 'node_modules/' directory.
     `);
   }
-
-  if (isBabelLatest) {
-    require(babelLatest);
-  } else {
-    require(babelPrev);
+  if (!global._babelPolyfill) {
+    if (isBabelLatest) {
+      require(babelLatest);
+    } else {
+      require(babelPrev);
+    }
   }
 }
 


### PR DESCRIPTION
I think this patch will actually fix #16. Just explain again in the following

for the users who wrote webpack with es6 and there are two way to run
first is using ```babel-node```, second is ```node --harmony``` and add ```require('babel/register');``` at entry point. For these both condition, it will load ```babel/polyfill``` at first in runtime, so we need add a flag to avoid ```bootstrap-loader``` to load ```babel/polyfill``` again.

So I thinks this patch can fix ```ERROR in only one instance of babel-polyfill is allowed``` issue correctly.
btw, I think I can make the code more clean in the beginning of ```src/bootstrap.loader.js```, if I have free time, I will do another PR

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/29)
<!-- Reviewable:end -->
