### PR TITLE
Update README.md to support Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ module: {
     // Use one of these to serve jQuery for Bootstrap scripts:
 
     // Bootstrap 3
-    { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery' },
+    { test:/bootstrap-sass[\/\\]assets[\/\\]javascripts[\/\\]/, loader: 'imports?jQuery=jquery' },
 
     // Bootstrap 4
-    { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery' },
+    { test: /bootstrap[\/\\]dist[\/\\]js[\/\\]umd[\/\\]/, loader: 'imports?jQuery=jquery' },
   ],
 },
 ```


### PR DESCRIPTION
You need to use use [\/\\] instead of \/ to match folder separators on Windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/44)
<!-- Reviewable:end -->
