### PR TITLE
README - Windows support for import-loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,10 @@ module: {
     // Use one of these to serve jQuery for Bootstrap scripts:
 
     // Bootstrap 3
-    { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery' },
+    { test: /bootstrap-sass[\\\/]assets[\\\/]javascripts[\\\/]/, loader: 'imports?jQuery=jquery' },
 
     // Bootstrap 4
-    { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery' },
+    { test: /bootstrap[\\\/]dist[\\\/]js[\\\/]umd[\\\/]/, loader: 'imports?jQuery=jquery' },
   ],
 },
 ```


### PR DESCRIPTION
The configuration for `imports-loader` works for Linux but not for Windows:
https://github.com/shakacode/bootstrap-loader/issues/47

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/62)
<!-- Reviewable:end -->
