### PR TITLE
Added module.exports for required files, exposing inner functions

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,1 +1,1 @@
-require('./lib/bootstrap.loader!./no-op.js');
+module.exports = require('./lib/bootstrap.loader!./no-op.js');

--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -97,7 +97,7 @@ module.exports.pitch = function(source) {
 
   global.__BOOTSTRAP_CONFIG__ = config;
 
-  const result = [];
+  const result = {};
 
   const dummySourceRel = (
     loaderUtils.urlToRequest(path.relative(this.context, source))
@@ -134,7 +134,7 @@ module.exports.pitch = function(source) {
     );
     const styles = styleLoaders + bootstrapStylesLoader + dummySourceRel;
 
-    result.push(createRequire(styles));
+    result.css = createRequire(styles);
   }
 
   // Handle scripts
@@ -151,13 +151,14 @@ module.exports.pitch = function(source) {
     );
     const scripts = bootstrapScriptsLoader + dummySourceRel;
 
-    result.push(createRequire(scripts));
+    result.js = createRequire(scripts);
   }
 
   const resultOutput = (
-    result
-      .map(loader => loader + '\n')
-      .join('')
+    Object.keys(result).map(key => {
+      'module.exports.' + key + ' = ' + loader + '\n'
+    }).join('')
+      
   );
 
   logger.debug('Requiring:', '\n', resultOutput);

--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -156,9 +156,8 @@ module.exports.pitch = function(source) {
 
   const resultOutput = (
     Object.keys(result).map(key => {
-      'module.exports.' + key + ' = ' + loader + '\n'
+      return 'module.exports.' + key + ' = ' + result[key] + '\n';
     }).join('')
-      
   );
 
   logger.debug('Requiring:', '\n', resultOutput);


### PR DESCRIPTION
Hi guys. I've put this together rather quickly, so apologies if it's a bit hack-ish. I came to needing to do this as I use https://github.com/kriasoft/isomorphic-style-loader for handling CSS on the server, which I explicitly set within a ```<style>``` tag inside a root ```Html``` React component when rendering from the server.

The isomorphic-style-loader adds a number of exports to the required CSS file, the one I was after namely being ```_getCss()```. However with the bootstrap-loader it was trapped within other ```require```s, alongside the Bootstrap JS for example (if any was set to be included within ```.bootstraprc```.

[This issue](https://github.com/shakacode/bootstrap-loader/issues/10) explains it quite well, and the final solution is very similar to what @halt-hammerzeit mentioned.

Once again, just put this together quickly, let me know thoughts/direction/what more I can do :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/98)
<!-- Reviewable:end -->
