### PR TITLE
Add support for `"extract-text-webpack-plugin": "~2.0.0-beta"`

### DIFF
--- a/src/utils/buildExtractStylesLoader.js
+++ b/src/utils/buildExtractStylesLoader.js
@@ -28,5 +28,5 @@ export default function(loaders) {
       .map(loader => loader + '!')
       .join('')
   );
-  return ExtractTextPlugin.extract('style', restLoaders);
+  return ExtractTextPlugin.extract({ fallbackLoader: 'style',loader: restLoaders });
 }


### PR DESCRIPTION
It prevents the following error when upgrading to
extract-text-webpack-plugin 2 beta. This will probebly breaks projects with older extract-text-webpack-plugin versions. Is it possible that we have a new `bootstrap-loader` beta release with `extract-text-webpack-plugin 2 beta` support ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/105)
<!-- Reviewable:end -->
