### PR TITLE
Adding extract text plugin as a peer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 node_modules/
 *.log
 .DS_Store
+*/**/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ lib/
 node_modules/
 *.log
 .DS_Store
-**/.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ lib/
 node_modules/
 *.log
 .DS_Store
-*/**/.idea/
+**/.idea/

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ styleLoaders:
 
 Default: `false`
 
-Extract styles to stand-alone css file using `extract-text-webpack-plugin`. See [extract-text-plugin](https://github.com/webpack/extract-text-webpack-plugin) for more details.
+Extract styles to stand-alone css file using `extract-text-webpack-plugin` version `1.0.1` or lower. See [extract-text-plugin](https://github.com/webpack/extract-text-webpack-plugin) for more details.
 
 ```yaml
 extractStyles: false

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ styleLoaders:
 
 Default: `false`
 
-Extract styles to stand-alone css file using `extract-text-webpack-plugin` version `1.0.1` or lower. See [extract-text-plugin](https://github.com/webpack/extract-text-webpack-plugin) for more details.
+Extract styles to stand-alone css file using `extract-text-webpack-plugin` lower than 2.0.0. See [extract-text-plugin](https://github.com/webpack/extract-text-webpack-plugin) for more details.
 
 ```yaml
 extractStyles: false

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -50,8 +50,9 @@
     "css-loader": "^0.22.0",
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
-    "extract-text-webpack-plugin": "~1.0.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
+    "font-awesome-loader": "^0.0.1",
     "imports-loader": "^0.6.5",
     "node-sass": "^3.4.2",
     "nodemon": "^1.8.1",
@@ -60,7 +61,6 @@
     "sass-loader": "^3.1.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",
-    "font-awesome-loader": "^0.0.1",
     "webpack": "^1.12.4",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.5.0"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -50,7 +50,7 @@
     "css-loader": "^0.22.0",
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
-    "extract-text-webpack-plugin": "^0.9.1",
+    "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "^0.8.4",
     "imports-loader": "^0.6.5",
     "node-sass": "^3.4.2",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -52,7 +52,7 @@
     "eslint-config-airbnb": "^1.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
-    "font-awesome-loader": "^0.0.1",
+    "font-awesome-loader": "^1.0.0",
     "imports-loader": "^0.6.5",
     "node-sass": "^3.4.2",
     "nodemon": "^1.8.1",

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -62,6 +62,7 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.4",
+    "font-awesome-loader": "^0.0.1",
     "node-sass": "^3.4.2",
     "nodemon": "^1.9.1",
     "postcss-loader": "^0.8.1",
@@ -72,7 +73,6 @@
     "sass-loader": "^3.1.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",
-    "font-awesome-loader": "^0.0.1",
     "webpack": "^1.12.6",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.5.0"

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -62,7 +62,7 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.4",
-    "font-awesome-loader": "^0.0.1",
+    "font-awesome-loader": "^1.0.0",
     "node-sass": "^3.4.2",
     "nodemon": "^1.9.1",
     "postcss-loader": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "peerDependencies": {
     "css-loader": "*",
-    "extract-text-webpack-plugin": "<=1.0.1",
+    "extract-text-webpack-plugin": "<2.0.0",
     "node-sass": "*",
     "resolve-url-loader": "*",
     "sass-loader": "*",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   ],
   "peerDependencies": {
     "css-loader": "*",
+    "extract-text-webpack-plugin": "<=1.0.1",
     "node-sass": "*",
     "resolve-url-loader": "*",
     "sass-loader": "*",


### PR DESCRIPTION
`bootstrap-loader` breaks when `extract-text-webpack-plugin` `2.0.0-beta.0` or higher is used. By adding  `extract-text-webpack-plugin` as a peer dependency with the supported version we can warn to user about this.

![screen shot 2016-07-25 at 11 27 29](https://cloud.githubusercontent.com/assets/8151667/17098816/53e64bca-525c-11e6-86fb-da6216486fbb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/109)
<!-- Reviewable:end -->
