### PR TITLE
Added support for javascript config file

### DIFF
--- a/src/utils/parseConfig.js
+++ b/src/utils/parseConfig.js
@@ -8,7 +8,12 @@ import stripComments from 'strip-json-comments';
  * @param {string} configPath
  * @returns {Object}
  */
-export default function(configPath) {
-  const configContent = stripComments(fs.readFileSync(configPath, 'utf8'));
+export default function(configPath) {  
+  try {
+    const configContent = JSON.stringify(require(configPath));
+  } catch (e) {
+    const configContent = stripComments(fs.readFileSync(configPath, 'utf8'));
+  }
+
   return yaml.safeLoad(configContent);
 }


### PR DESCRIPTION
#125 Added support for javascript config file by trying to stringify the file in JSON after requiring it with CommonsJS. If the stringify fails for any reason, the original `fs.readFileSync` kicks in and process the file in the original way.

The addition supports v1 and v2 AFIK.
