### PR TITLE
Fix debug messages logging

### DIFF
--- a/src/bootstrap.config.js
+++ b/src/bootstrap.config.js
@@ -6,7 +6,6 @@ import parseConfig from './utils/parseConfig';
 import selectModules from './utils/selectModules';
 import selectUserModules from './utils/selectUserModules';
 import getEnvProp from './utils/getEnvProp';
-import logger from './utils/logger';
 
 /* ======= Fetching config */
 
@@ -76,8 +75,6 @@ export function createConfig({
   configFilePath,
 }) {
   if (!configFilePath) {
-    logger.debug('Using default bootstrap 3 configuration');
-
     setConfigVariables();
     return {
       bootstrapVersion: parseInt(rawConfig.bootstrapVersion, 10),
@@ -92,9 +89,6 @@ export function createConfig({
   }
 
   const configFile = path.resolve(__dirname, configFilePath);
-
-  logger.debug(`bootstrap-loader is using config file at ${configFile}`);
-
   setConfigVariables(configFile);
   const configDir = path.dirname(configFile);
   const preBootstrapCustomizations = (

--- a/src/bootstrap.config.js
+++ b/src/bootstrap.config.js
@@ -12,8 +12,6 @@ import logger from './utils/logger';
 
 const DEFAULT_VERSION = 3;
 const SUPPORTED_VERSIONS = [3, 4];
-const CONFIG_FILE = '.bootstraprc';
-const defaultUserConfigPath = `../../../${CONFIG_FILE}`;
 
 let rawConfig;
 let defaultConfig;
@@ -49,17 +47,22 @@ function setConfigVariables(configFilePath) {
     }
 
     const defaultConfigPath = (
-      resolveDefaultConfigPath(CONFIG_FILE, bootstrapVersion)
+      resolveDefaultConfigPath(bootstrapVersion)
     );
     defaultConfig = parseConfig(defaultConfigPath);
   } else {
     const defaultConfigPath = (
-      resolveDefaultConfigPath(CONFIG_FILE, DEFAULT_VERSION)
+      resolveDefaultConfigPath(DEFAULT_VERSION)
     );
+
+    if (!fileExists(defaultConfigPath)) {
+      throw new Error(`No default config file at ${defaultConfigPath}'`);
+    }
+
     rawConfig = defaultConfig = parseConfig(defaultConfigPath);
 
     if (!rawConfig) {
-      throw new Error(`No default config file at ${defaultConfigPath}'`);
+      throw new Error(`I cannot parse the config file at ${defaultConfigPath}'`);
     }
   }
 }
@@ -70,58 +73,54 @@ export { userConfigFileExists };
 
 export function createConfig({
   extractStyles,
-  configFilePath = defaultUserConfigPath,
+  configFilePath,
 }) {
-  const configFile = path.resolve(__dirname, configFilePath);
+  if (!configFilePath) {
+    logger.debug('Using default bootstrap 3 configuration');
 
-  if (userConfigFileExists(configFile)) {
-    logger.log(`bootstrap-loader is using config file at ${configFile}`);
-
-    setConfigVariables(configFile);
-    const configDir = path.dirname(configFile);
-    const preBootstrapCustomizations = (
-      rawConfig.preBootstrapCustomizations &&
-      path.resolve(configDir, rawConfig.preBootstrapCustomizations)
-    );
-    const bootstrapCustomizations = (
-      rawConfig.bootstrapCustomizations &&
-      path.resolve(configDir, rawConfig.bootstrapCustomizations)
-    );
-    const appStyles = (
-      rawConfig.appStyles &&
-      path.resolve(configDir, rawConfig.appStyles)
-    );
-
+    setConfigVariables();
     return {
       bootstrapVersion: parseInt(rawConfig.bootstrapVersion, 10),
       loglevel: rawConfig.loglevel,
-      preBootstrapCustomizations,
-      bootstrapCustomizations,
-      appStyles,
-      useFlexbox: rawConfig.useFlexbox,
-      useCustomIconFontPath: rawConfig.useCustomIconFontPath,
-      extractStyles: extractStyles || getEnvProp('extractStyles', rawConfig),
-      styleLoaders: rawConfig.styleLoaders,
-      styles: selectUserModules(rawConfig.styles, defaultConfig.styles),
-      scripts: selectUserModules(rawConfig.scripts, defaultConfig.scripts),
+      useFlexbox: defaultConfig.useFlexbox,
+      useCustomIconFontPath: defaultConfig.useCustomIconFontPath,
+      extractStyles: extractStyles || getEnvProp('extractStyles', defaultConfig),
+      styleLoaders: defaultConfig.styleLoaders,
+      styles: selectModules(defaultConfig.styles),
+      scripts: selectModules(defaultConfig.scripts),
     };
   }
 
-  if (configFile) {
-    logger.log(`bootstrap-loader config file ${configFile} was not found.
-  Using default bootstrap 3 configuration`);
-  }
+  const configFile = path.resolve(__dirname, configFilePath);
 
-  // Or else we're using the default config file
-  setConfigVariables();
+  logger.debug(`bootstrap-loader is using config file at ${configFile}`);
+
+  setConfigVariables(configFile);
+  const configDir = path.dirname(configFile);
+  const preBootstrapCustomizations = (
+    rawConfig.preBootstrapCustomizations &&
+    path.resolve(configDir, rawConfig.preBootstrapCustomizations)
+  );
+  const bootstrapCustomizations = (
+    rawConfig.bootstrapCustomizations &&
+    path.resolve(configDir, rawConfig.bootstrapCustomizations)
+  );
+  const appStyles = (
+    rawConfig.appStyles &&
+    path.resolve(configDir, rawConfig.appStyles)
+  );
+
   return {
     bootstrapVersion: parseInt(rawConfig.bootstrapVersion, 10),
     loglevel: rawConfig.loglevel,
-    useFlexbox: defaultConfig.useFlexbox,
-    useCustomIconFontPath: defaultConfig.useCustomIconFontPath,
-    extractStyles: extractStyles || getEnvProp('extractStyles', defaultConfig),
-    styleLoaders: defaultConfig.styleLoaders,
-    styles: selectModules(defaultConfig.styles),
-    scripts: selectModules(defaultConfig.scripts),
+    preBootstrapCustomizations,
+    bootstrapCustomizations,
+    appStyles,
+    useFlexbox: rawConfig.useFlexbox,
+    useCustomIconFontPath: rawConfig.useCustomIconFontPath,
+    extractStyles: extractStyles || getEnvProp('extractStyles', rawConfig),
+    styleLoaders: rawConfig.styleLoaders,
+    styles: selectUserModules(rawConfig.styles, defaultConfig.styles),
+    scripts: selectUserModules(rawConfig.scripts, defaultConfig.scripts),
   };
 }

--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -69,30 +69,35 @@ module.exports.pitch = function(source) {
     if (config.loglevel === 'debug') {
       return true;
     }
-    if (process.env.DEBUG) {
-      const globalDebugVar = process.env.DEBUG.toString().toLowerCase();
-      switch (globalDebugVar) {
-        case 'true':
-        case 'yes':
-        case '1':
-          return true;
-        default:
-          return false;
-      }
+    if (!process.env.DEBUG) {
+      return false;
     }
-    return false;
+
+    switch (process.env.DEBUG.toString().toLowerCase()) {
+      case 'true':
+      case 'yes':
+      case '1':
+        return true;
+      default:
+        return false;
+    }
   }
 
   global.__DEBUG__ = isDebugEnabled();
 
-  if (global.__DEBUG__) {
-    logger.debug(`Hey, we're in DEBUG mode because you have 
-      ${(process.env.DEBUG
-        ? 'DEBUG defined in your ENV.'
-        : 'your config log level set to \'debug\'.')}`);
+  logger.debug(`Hey, we're in DEBUG mode because you have
+    ${(process.env.DEBUG
+      ? 'DEBUG defined in your ENV.'
+      : 'your config log level set to \'debug\'.')}`);
 
-    logger.debug('Query from webpack config:', this.query || '*none*');
+  if (!configFilePath) {
+    logger.debug('Using default bootstrap 3 configuration');
+  } else {
+    const configFile = path.resolve(__dirname, configFilePath);
+    logger.debug(`bootstrap-loader is using config file at ${configFile}`);
   }
+
+  logger.debug('Query from webpack config:', this.query || '*none*');
 
   const bootstrapVersion = config.bootstrapVersion;
 

--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -85,10 +85,11 @@ module.exports.pitch = function(source) {
 
   global.__DEBUG__ = isDebugEnabled();
 
-  logger.debug(`Hey, we're in DEBUG mode because you have
-    ${(process.env.DEBUG
-      ? 'DEBUG defined in your ENV.'
-      : 'your config log level set to \'debug\'.')}`);
+  const whichWayDebugEnabledMsg = process.env.DEBUG
+    ? 'DEBUG defined in your ENV.'
+    : "your config log level set to 'debug'.";
+
+  logger.debug(`Hey, we're in DEBUG mode because you have ${whichWayDebugEnabledMsg}`);
 
   if (!configFilePath) {
     logger.debug('Using default bootstrap 3 configuration');

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -25,7 +25,7 @@ export default {
    * @param {...*} output
    */
   debug(...output) {
-    if (__DEBUG__) this.log(...output);
+    if (global.__DEBUG__) this.log(...output);
   },
 
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -13,10 +13,10 @@ export default {
    * @param {...*} output
    */
   log(...output) {
-    const pettyOutput = (
+    const prettyOutput = (
       [chalk.yellow('[bootstrap-loader]: ')].concat(output, '\n')
     );
-    console.log(...pettyOutput);
+    console.log(...prettyOutput);
   },
 
   /**

--- a/src/utils/resolveDefaultConfigPath.js
+++ b/src/utils/resolveDefaultConfigPath.js
@@ -1,5 +1,7 @@
 import path from 'path';
 
+const CONFIG_FILE = '.bootstraprc';
+
 /**
  * Resolves default config for default Bootstrap version
  *
@@ -7,6 +9,6 @@ import path from 'path';
  * @param {number} bootstrapPathotstrapVersion
  * @returns {string}
  */
-export default (configFile, bootstrapVersion) => (
-  path.resolve(__dirname, `../../${configFile}-${bootstrapVersion}-default`)
+export default (bootstrapVersion) => (
+  path.resolve(__dirname, `../../${CONFIG_FILE}-${bootstrapVersion}-default`)
 );


### PR DESCRIPTION
Instead of #121
Resolves #120

--
```js
export function createConfig({
  extractStyles,
  configFilePath = defaultUserConfigPath, // <== This was the main point of the pain
}) {
```
The rest is just consequences of removing the technical debt (part of it).

I've moved to the beginning the `default config path` handling in `createConfig()`
with the guard check
```js
if (!configFilePath) {
   logger.debug('Using default bootstrap 3 configuration');
```
and the rest of `createConfig()` is the old `user provided config path` handling.

--
`petty` => `pretty`

--
And I've moved the constant
```js
const CONFIG_FILE = '.bootstraprc';
```
to the place it belongs to. `resolveDefaultConfigPath()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/133)
<!-- Reviewable:end -->
