### PR TITLE
Update dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,3 +14,5 @@ rules:
   import/no-unresolved: 0
   no-underscore-dangle: [ "error", { "allow": [ "__BOOTSTRAP_CONFIG__", "__DEBUG__", "_babelPolyfill" ] } ]
 
+  # https://github.com/benmosher/eslint-plugin-import/issues/340
+  import/no-extraneous-dependencies: 0

--- a/src/bootstrap.loader.js
+++ b/src/bootstrap.loader.js
@@ -26,6 +26,9 @@ if (semver.lt(process.version, '4.0.0') && !global._babelPolyfill) {
   }
 }
 
+// Read more about the next line
+// at https://github.com/shakacode/bootstrap-loader/pull/139
+/* eslint-disable import/imports-first */
 import path from 'path';
 import loaderUtils from 'loader-utils';
 

--- a/src/utils/getEnvProp.js
+++ b/src/utils/getEnvProp.js
@@ -6,14 +6,14 @@
  * @returns {*}
  */
 export default function(prop, config) {
-  if (config.hasOwnProperty(prop)) {
+  if (prop in config) {
     return config[prop];
   }
 
   const NODE_ENV = process.env.NODE_ENV;
   const configEnvSection = config.env && config.env[NODE_ENV];
 
-  if (configEnvSection && configEnvSection.hasOwnProperty(prop)) {
+  if (configEnvSection && (prop in configEnvSection)) {
     return configEnvSection[prop];
   }
   return false;


### PR DESCRIPTION
The follow up of https://github.com/shakacode/bootstrap-loader/pull/136

--
A note about [`/* eslint-disable import/imports-first */`](https://github.com/shakacode/bootstrap-loader/compare/master...AlexKVal:update-deps?expand=1#diff-f3ffaeedec1d3a619e6f02878e28c941R29) in bootstrap.loader.js

[ES6 imports are hoisted](http://stackoverflow.com/questions/29329662/are-es6-module-imports-hoisted).
Probably something needs to be done about it (in another issue).
Maybe drop `node-0.12` support or rewrite somehow this checking of node version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/139)
<!-- Reviewable:end -->
