### PR TITLE
Add bootstrap@4.0.0.alpha.4 compatibility

### DIFF
--- a/.bootstraprc-4-default
+++ b/.bootstraprc-4-default
@@ -79,8 +79,6 @@ styles:
   card: true
   breadcrumb: true
   pagination: true
-  pager: true
-  labels: true
   jumbotron: true
   alert: true
   progress: true
@@ -88,6 +86,7 @@ styles:
   list-group: true
   responsive-embed: true
   close: true
+  tags: true
 
   # Components w/ JavaScript
   modal: true
@@ -97,9 +96,6 @@ styles:
 
   # Utility classes
   utilities: true
-  utilities-background: true
-  utilities-spacing: true
-  utilities-responsive: true
 
 ### Bootstrap scripts
 scripts:

--- a/examples/basic/.bootstraprc-4-example
+++ b/examples/basic/.bootstraprc-4-example
@@ -88,8 +88,6 @@ styles:
   card: true
   breadcrumb: true
   pagination: true
-  pager: true
-  labels: true
   jumbotron: true
   alert: true
   progress: true
@@ -97,6 +95,7 @@ styles:
   list-group: true
   responsive-embed: true
   close: true
+  tags: true
 
   # Components w/ JavaScript
   modal: true
@@ -106,8 +105,6 @@ styles:
 
   # Utility classes
   utilities: true
-  utilities-spacing: true
-  utilities-responsive: true
 
 ### Bootstrap scripts
 scripts:

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -54,7 +54,7 @@
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.18",
     "body-parser": "^1.15.2",
-    "bootstrap-loader": "file:///C:\\projects\\bootstrap-loader",
+    "bootstrap-loader": "^2.0.0-beta",
     "css-loader": "^0.23.1",
     "eslint": "^2.0.0",
     "eslint-config-shakacode": "^5.0.0",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.13.3",
-    "bootstrap": "4.0.0-alpha.2",
+    "bootstrap": "4.0.0-alpha.4",
     "bootstrap-sass": "^3.3.6",
     "font-awesome": "^4.6.3",
     "jquery": "^2.1.4",
@@ -54,7 +54,7 @@
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.18",
     "body-parser": "^1.15.2",
-    "bootstrap-loader": "^2.0.0-beta",
+    "bootstrap-loader": "file:///C:\\projects\\bootstrap-loader",
     "css-loader": "^0.23.1",
     "eslint": "^2.0.0",
     "eslint-config-shakacode": "^5.0.0",

--- a/examples/css-modules/.bootstraprc-4-example
+++ b/examples/css-modules/.bootstraprc-4-example
@@ -69,8 +69,6 @@ styles:
   card: true
   breadcrumb: true
   pagination: true
-  pager: true
-  labels: true
   jumbotron: true
   alert: true
   progress: true
@@ -78,6 +76,7 @@ styles:
   list-group: true
   responsive-embed: true
   close: true
+  tags: true
 
   # Components w/ JavaScript
   modal: true
@@ -87,8 +86,6 @@ styles:
 
   # Utility classes
   utilities: true
-  utilities-spacing: true
-  utilities-responsive: true
 
 ### Bootstrap scripts
 scripts: false

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -60,7 +60,7 @@
     "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "bootstrap-loader": "file:///C:\\projects\\bootstrap-loader",
+    "bootstrap-loader": "^2.0.0-beta",
     "css-loader": "^0.23.1",
     "eslint": "^2.0.0",
     "eslint-config-shakacode": "^5.0.0",

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "body-parser": "^1.15.0",
-    "bootstrap": "4.0.0-alpha.2",
+    "bootstrap": "4.0.0-alpha.4",
     "bootstrap-sass": "^3.3.6",
     "express": "^4.13.4",
     "font-awesome": "^4.6.3",
@@ -60,7 +60,7 @@
     "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "bootstrap-loader": "^2.0.0-beta",
+    "bootstrap-loader": "file:///C:\\projects\\bootstrap-loader",
     "css-loader": "^0.23.1",
     "eslint": "^2.0.0",
     "eslint-config-shakacode": "^5.0.0",

--- a/src/utils/createBootstrapRequire.js
+++ b/src/utils/createBootstrapRequire.js
@@ -12,7 +12,7 @@ export default function(module, bootstrapVersion, bootstrapPath) {
   const scriptsPath = (
     parseInt(bootstrapVersion, 10) === 3 ?
     ['assets', 'javascripts', 'bootstrap'] :
-    ['dist', 'js', 'umd']
+    ['js', 'dist']
   );
   const bootstrapModule = path.join(bootstrapPath, ...scriptsPath, module);
   return `require (${JSON.stringify(bootstrapModule)});`;


### PR DESCRIPTION
## Most notable changes:
- `label` component renamed to `tag` (https://github.com/twbs/bootstrap/pull/19157)
- `pager` component dropped (https://github.com/twbs/bootstrap/pull/18782)
- `utilities-*` now reside in the `utilities` folder
- Scripts now reside in the `js/dist` folder instead of `dist/js/umd`

## Issues
- To avoid the added complexity of loading styles in sub-folders I've removed `utilities-*` options. We can discuss a good way to implement this if it's needed.

Passes the test~~s~~ and the examples work fine. Theoretically fixes #117.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/167)
<!-- Reviewable:end -->
