### PR TITLE
Fix #201: Enforce -loader suffix when processing loaders to handle old & new Webpack compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. Items under
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+##### Added
+- Ensures `-loader` suffix automatically for style loaders to safely keep compatibility with old Webpack versions as well as new versions with the suffix requirement from Webpack v2.1.0-beta.26 and onward. [#205](https://github.com/shakacode/bootstrap-loader/pull/205) by [kevinzwhuang](https://github.com/kevinzwhuang).
 
 ## [2.0.0.beta.14] - 2016-11-14
 ##### Added

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Note that :`__dirname` is a [global variable](https://nodejs.org/docs/latest/api
 useFlexbox: true
 
 styleLoaders:
-  - style
-  - css
-  - sass
+  - style-loader
+  - css-loader
+  - sass-loader
 
 styles:
   normalize: true
@@ -125,7 +125,7 @@ scripts:
   // And JSON comments also!
   "useFlexbox": true,
 
-  "styleLoaders": ["style", "css", "sass"],
+  "styleLoaders": ["style-loader", "css-loader", "sass-loader"],
 
   "styles": {
     "normalize": true,
@@ -203,18 +203,22 @@ bootstrapVersion: 3
 
 #### `styleLoaders`
 
-Default: `[ 'style', 'css', 'sass' ]`
+Default: `[ 'style-loader', 'css-loader', 'sass-loader' ]`
 
 Array of webpack loaders. `sass-loader` is required, order matters. In most cases the style loader should definitely go first and the sass loader should be last.
 
+Note: Beginning with Webpack v2.1.0-beta.26, the '-loader' suffix is required for all loaders.
+To maintain compatibility with older versions, all accepted style loaders (style, css, sass, resolve-url) are automatically appended with '-loader'.
+It is recommended that you explicitly state the '-loader' suffix for every webpack loader in `styleLoaders` to ensure compatibility in the long term.
+
 ```yaml
 styleLoaders:
-  - style
-  - css
-  - sass
+  - style-loader
+  - css-loader
+  - sass-loader
 
 # You can apply loader params here:
-  - sass?outputStyle=expanded
+  - sass-loader?outputStyle=expanded
 ```
 
 #### `extractStyles`
@@ -372,10 +376,10 @@ This was made possible thanks to [resolve-url-loader](https://github.com/bhollow
 
 ```yaml
 styleLoaders:
-  - style
-  - css?sourceMap
-  - resolve-url?sourceMap
-  - sass?sourceMap
+  - style-loader
+  - css-loader?sourceMap
+  - resolve-url-loader?sourceMap
+  - sass-loader?sourceMap
 ```
 
 #### Incorporating Bootswatch themes
@@ -405,10 +409,10 @@ module: {
     // Use one of these to serve jQuery for Bootstrap scripts:
 
     // Bootstrap 3
-    { test:/bootstrap-sass[\/\\]assets[\/\\]javascripts[\/\\]/, loader: 'imports?jQuery=jquery' },
+    { test:/bootstrap-sass[\/\\]assets[\/\\]javascripts[\/\\]/, loader: 'imports-loader?jQuery=jquery' },
 
     // Bootstrap 4
-    { test: /bootstrap[\/\\]dist[\/\\]js[\/\\]umd[\/\\]/, loader: 'imports?jQuery=jquery' },
+    { test: /bootstrap[\/\\]dist[\/\\]js[\/\\]umd[\/\\]/, loader: 'imports-loader?jQuery=jquery' },
   ],
 },
 ```
@@ -417,10 +421,10 @@ Note: if you're not concerned about Windows, the lines look like this (simpler r
 
 ```js
 // Boostrap 3
-{ test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery' },
+{ test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports-loader?jQuery=jquery' },
 
 // Bootstrap 4
-{ test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery' },
+{ test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery' },
 ```
 
 
@@ -430,8 +434,8 @@ Bootstrap uses **icon fonts**. If you want to load them, don't forget to setup `
 ```js
 module: {
   loaders: [
-    { test: /\.(woff2?|svg)$/, loader: 'url?limit=10000' },
-    { test: /\.(ttf|eot)$/, loader: 'file' },
+    { test: /\.(woff2?|svg)$/, loader: 'url-loader?limit=10000' },
+    { test: /\.(ttf|eot)$/, loader: 'file-loader' },
   ],
 },
 ```
@@ -454,10 +458,10 @@ module.exports = {
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract(
-          'style',
-          'css?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
-          '!sass' +
-          '!sass-resources'
+          'style-loader',
+          'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
+          '!sass-loader' +
+          '!sass-resources-loader'
         ),
       },
       // stuff removed for clarity ...

--- a/examples/basic/.bootstraprc-3-example
+++ b/examples/basic/.bootstraprc-3-example
@@ -10,9 +10,9 @@ useCustomIconFontPath: false
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - sass
+  - style-loader
+  - css-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/basic/.bootstraprc-4-example
+++ b/examples/basic/.bootstraprc-4-example
@@ -10,10 +10,10 @@ useFlexbox: true
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - postcss
-  - sass
+  - style-loader
+  - css-loader
+  - postcss-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -70,7 +70,7 @@
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
-    "webpack": "2.1.0-beta.1 - 2.1.0-beta.25",
+    "webpack": "^2.1.0-beta",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.1"
   }

--- a/examples/basic/webpack.dev.config.js
+++ b/examples/basic/webpack.dev.config.js
@@ -42,24 +42,24 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.css$/, loaders: ['style', 'css', 'postcss'] },
-      { test: /\.scss$/, loaders: ['style', 'css', 'postcss', 'sass'] },
+      { test: /\.css$/, loaders: ['style-loader', 'css-loader', 'postcss-loader'] },
+      { test: /\.scss$/, loaders: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'] },
       {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: 'url?limit=10000',
+        loader: 'url-loader?limit=10000',
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file',
+        loader: 'file-loader',
       },
 
       // Use one of these to serve jQuery for Bootstrap scripts:
 
       // Bootstrap 4
-      { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery' },
+      { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery' },
 
       // Bootstrap 3
-      { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery' },
+      { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports-loader?jQuery=jquery' },
     ],
   },
 

--- a/examples/basic/webpack.prod.config.js
+++ b/examples/basic/webpack.prod.config.js
@@ -42,30 +42,30 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.css$/, loader: ExtractTextPlugin.extract({
-        fallbackLoader: 'style', loader: 'css!postcss',
+        fallbackLoader: 'style-loader', loader: 'css-loader!postcss-loader',
       }) },
       { test: /\.scss$/, loader: ExtractTextPlugin.extract({
-        fallbackLoader: 'style', loader: 'css!postcss!sass',
+        fallbackLoader: 'style-loader', loader: 'css-loader!postcss-loader!sass-loader',
       }) },
 
       {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         // Limiting the size of the woff fonts breaks font-awesome ONLY for the extract text plugin
         // loader: "url?limit=10000"
-        loader: 'url',
+        loader: 'url-loader',
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file',
+        loader: 'file-loader',
       },
 
       // Use one of these to serve jQuery for Bootstrap scripts:
 
       // Bootstrap 4
-      { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery' },
+      { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery' },
 
       // Bootstrap 3
-      { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery' },
+      { test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports-loader?jQuery=jquery' },
     ],
   },
 

--- a/examples/css-modules/.bootstraprc-3-example
+++ b/examples/css-modules/.bootstraprc-3-example
@@ -10,9 +10,9 @@ useCustomIconFontPath: false
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - sass
+  - style-loader
+  - css-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/css-modules/.bootstraprc-4-example
+++ b/examples/css-modules/.bootstraprc-4-example
@@ -10,10 +10,10 @@ useFlexbox: true
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - postcss
-  - sass
+  - style-loader
+  - css-loader
+  - postcss-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -81,7 +81,7 @@
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
-    "webpack": "2.1.0-beta.1 - 2.1.0-beta.25",
+    "webpack": "^2.1.0-beta",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.1"
   }

--- a/examples/css-modules/webpack.dev.config.js
+++ b/examples/css-modules/webpack.dev.config.js
@@ -44,33 +44,33 @@ module.exports = {
     loaders: [
       {
         test: /\.jsx?$/,
-        loaders: ['babel'],
+        loaders: ['babel-loader'],
         exclude: /node_modules/,
       },
       {
         test: /\.css$/,
         loaders: [
-          'style',
-          'css?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]',
-          'postcss',
+          'style-loader',
+          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]',
+          'postcss-loader',
         ],
       },
       {
         test: /\.scss$/,
         loaders: [
-          'style',
-          'css?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]',
-          'postcss',
-          'sass',
+          'style-loader',
+          'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]',
+          'postcss-loader',
+          'sass-loader',
         ],
       },
       {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: 'url?limit=10000',
+        loader: 'url-loader?limit=10000',
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file',
+        loader: 'file-loader',
       },
     ],
   },

--- a/examples/css-modules/webpack.prod.config.js
+++ b/examples/css-modules/webpack.prod.config.js
@@ -47,24 +47,24 @@ module.exports = {
     loaders: [
       {
         test: /\.jsx?$/,
-        loaders: ['babel'],
+        loaders: ['babel-loader'],
         exclude: /node_modules/,
       },
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style',
-          loader: 'css?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]' +
-          '!postcss',
+          fallbackLoader: 'style-loader',
+          loader: 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]' +
+          '!postcss-loader',
         }),
       },
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style',
-          loader: 'css?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
-            '!postcss' +
-          '!sass',
+          fallbackLoader: 'style-loader',
+          loader: 'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
+            '!postcss-loader' +
+          '!sass-loader',
         }),
       },
 
@@ -72,11 +72,11 @@ module.exports = {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         // Limiting the size of the woff fonts breaks font-awesome ONLY for the extract text plugin
         // loader: "url?limit=10000"
-        loader: 'url',
+        loader: 'url-loader',
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file',
+        loader: 'file-loader',
       },
     ],
   },

--- a/examples/multiple-entries/bs3.yml
+++ b/examples/multiple-entries/bs3.yml
@@ -10,9 +10,9 @@ useCustomIconFontPath: false
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - sass
+  - style-loader
+  - css-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/multiple-entries/bs4.yml
+++ b/examples/multiple-entries/bs4.yml
@@ -10,10 +10,10 @@ useFlexbox: true
 
 # Webpack loaders, order matters
 styleLoaders:
-  - style
-  - css
-  - postcss
-  - sass
+  - style-loader
+  - css-loader
+  - postcss-loader
+  - sass-loader
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/examples/multiple-entries/package.json
+++ b/examples/multiple-entries/package.json
@@ -59,7 +59,7 @@
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
-    "webpack": "2.1.0-beta.1 - 2.1.0-beta.25",
+    "webpack": "^2.1.0-beta",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.1"
   }

--- a/examples/multiple-entries/webpack.dev.config.js
+++ b/examples/multiple-entries/webpack.dev.config.js
@@ -28,23 +28,23 @@ module.exports = {
   resolve: {  extensions: ['*', '.js']  },
   module: {
     loaders: [
-      { test: /\.css$/, loaders: [ 'style', 'css', 'postcss' ] },
-      { test: /\.scss$/, loaders: [ 'style', 'css', 'postcss', 'sass' ] },
+      { test: /\.css$/, loaders: [ 'style-loader', 'css-loader', 'postcss-loader' ] },
+      { test: /\.scss$/, loaders: [ 'style-loader', 'css-loader', 'postcss-loader', 'sass-loader' ] },
       {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: "url?limit=10000"
+        loader: "url-loader?limit=10000"
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file'
+        loader: 'file-loader'
       },
       // Use one of these to serve jQuery for Bootstrap scripts:
 
       // Bootstrap 4
-      {test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery'},
+      {test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery'},
 
       // Bootstrap 3
-      {test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery'}]
+      {test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports-loader?jQuery=jquery'}]
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),

--- a/examples/multiple-entries/webpack.prod.config.js
+++ b/examples/multiple-entries/webpack.prod.config.js
@@ -47,18 +47,18 @@ module.exports = {
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style',
-          loader: 'css?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]' +
-          '!postcss',
+          fallbackLoader: 'style-loader',
+          loader: 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]' +
+          '!postcss-loader',
         }),
       },
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style',
-          loader: 'css?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
-            '!postcss' +
-          '!sass',
+          fallbackLoader: 'style-loader',
+          loader: 'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]' +
+            '!postcss-loader' +
+          '!sass-loader',
         }),
       },
 
@@ -66,20 +66,20 @@ module.exports = {
         test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         // Limiting the size of the woff fonts breaks font-awesome ONLY for the extract text plugin
         // loader: "url?limit=10000"
-        loader: "url"
+        loader: "url-loader"
       },
       {
         test: /\.(ttf|eot|svg)(\?[\s\S]+)?$/,
-        loader: 'file'
+        loader: 'file-loader'
       },
 
       // Use one of these to serve jQuery for Bootstrap scripts:
 
       // Bootstrap 4
-      {test: /bootstrap\/dist\/js\/umd\//, loader: 'imports?jQuery=jquery'},
+      {test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery'},
 
       // Bootstrap 3
-      {test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports?jQuery=jquery'},
+      {test: /bootstrap-sass\/assets\/javascripts\//, loader: 'imports-loader?jQuery=jquery'},
     ],
   },
 };

--- a/node_package/tests/utils/buildExtractStylesLoader.test.js
+++ b/node_package/tests/utils/buildExtractStylesLoader.test.js
@@ -15,14 +15,14 @@ test('buildExtractStylesLoader runs as expected', (assert) => {
     path.join(
       `${__dirname}`,
       '../../../node_modules/extract-text-webpack-plugin' +
-      '/loader.js?{"omit":1,"remove":true}!style!url-loader!css-loader!'
+      '/loader.js?{"omit":1,"remove":true}!style-loader!url-loader!css-loader!'
     )
   );
   assert.equals(buildExtractStylesLoader(['isomorphic-style-loader', 'url-loader', 'css-loader']),
     path.join(
       `${__dirname}`,
       '../../../node_modules/extract-text-webpack-plugin' +
-      '/loader.js?{"omit":1,"remove":true}!isomorphic-style!url-loader!css-loader!'
+      '/loader.js?{"omit":1,"remove":true}!isomorphic-style-loader!url-loader!css-loader!'
     )
   );
   assert.end();

--- a/node_package/tests/utils/processStyleLoaders.test.js
+++ b/node_package/tests/utils/processStyleLoaders.test.js
@@ -16,28 +16,28 @@ test('processStyleLoaders works as expected', (assert) => {
     processStyleLoaders({
       loaders: ['sass?sourceMap', 'resolve-url'],
     }),
-    ['sass?sourceMap', 'resolve-url']
+    ['sass-loader?sourceMap', 'resolve-url-loader']
   );
 
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['other', 'sass'],
     }),
-    ['other', 'resolve-url', 'sass?sourceMap']
+    ['other', 'resolve-url-loader', 'sass-loader?sourceMap']
   );
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['other', 'sass'],
       disableSassSourceMap: true,
     }),
-    ['other', 'resolve-url', 'sass']
+    ['other', 'resolve-url-loader', 'sass-loader']
   );
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['other', 'sass'],
       disableResolveUrlLoader: true,
     }),
-    ['other', 'sass?sourceMap']
+    ['other', 'sass-loader?sourceMap']
   );
   assert.deepEquals(
     processStyleLoaders({
@@ -45,28 +45,28 @@ test('processStyleLoaders works as expected', (assert) => {
       disableSassSourceMap: true,
       disableResolveUrlLoader: true,
     }),
-    ['other', 'sass']
+    ['other', 'sass-loader']
   );
 
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['other', 'sass?other'],
     }),
-    ['other', 'resolve-url', 'sass?other&sourceMap']
+    ['other', 'resolve-url-loader', 'sass-loader?other&sourceMap']
   );
   assert.deepEquals(
     processStyleLoaders({
-      loaders: ['other', 'sass?other'],
+      loaders: ['other', 'sass-loader?other'],
       disableSassSourceMap: true,
     }),
-    ['other', 'resolve-url', 'sass?other']
+    ['other', 'resolve-url-loader', 'sass-loader?other']
   );
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['other', 'sass?other'],
       disableResolveUrlLoader: true,
     }),
-    ['other', 'sass?other&sourceMap']
+    ['other', 'sass-loader?other&sourceMap']
   );
   assert.deepEquals(
     processStyleLoaders({
@@ -74,14 +74,14 @@ test('processStyleLoaders works as expected', (assert) => {
       disableSassSourceMap: true,
       disableResolveUrlLoader: true,
     }),
-    ['other', 'sass?other']
+    ['other', 'sass-loader?other']
   );
 
   assert.deepEquals(
     processStyleLoaders({
       loaders: ['sass?sourceMap'],
     }),
-    ['resolve-url', 'sass?sourceMap']
+    ['resolve-url-loader', 'sass-loader?sourceMap']
   );
   assert.end();
 });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "resolve-url-loader": "*",
     "sass-loader": "*",
     "url-loader": "*",
-    "webpack": "2.1.0-beta.1 - 2.1.0-beta.25"
+    "webpack": "^2.1.0-beta"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/src/utils/buildExtractStylesLoader.js
+++ b/src/utils/buildExtractStylesLoader.js
@@ -18,6 +18,11 @@ your 'styleLoaders' array starts with 'style' or 'isomorphic-style' at index 0.
     `);
   }
 
+  // Enforcement of loader suffix for Webpack v2.1.0+
+  if (loaders[0].endsWith('-loader')) {
+    fallbackLoader += '-loader';
+  }
+
   let ExtractTextPlugin;
   try {
     // eslint-disable-next-line global-require

--- a/src/utils/buildExtractStylesLoader.js
+++ b/src/utils/buildExtractStylesLoader.js
@@ -8,19 +8,14 @@
 export default function(loaders) {
   let fallbackLoader;
   if (loaders[0].startsWith('style')) {
-    fallbackLoader = 'style';
+    fallbackLoader = 'style-loader';
   } else if (loaders[0].startsWith('isomorphic-style')) {
-    fallbackLoader = 'isomorphic-style';
+    fallbackLoader = 'isomorphic-style-loader';
   } else {
     throw new Error(`
 If you want to use 'extract-text-webpack-plugin', make sure
 your 'styleLoaders' array starts with 'style' or 'isomorphic-style' at index 0.
     `);
-  }
-
-  // Enforcement of loader suffix for Webpack v2.1.0+
-  if (loaders[0].endsWith('-loader')) {
-    fallbackLoader += '-loader';
   }
 
   let ExtractTextPlugin;

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -4,8 +4,8 @@ import escapeRegExp from 'escape-regexp';
 
 // Ensures '-loader' suffix for loaders in config for webpack compatibility
 const ensureLoadersSuffix = loadersArray => {
-  const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
-  const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
+  const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^postcss-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
+  const suffixReplaceRegExp = new RegExp('^style|^css|^postcss|^sass|^resolve-url');
   return loadersArray.map(loader => {
     if (!loaderSuffixRegExp.test(loader)) {
       return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -2,6 +2,18 @@
 
 import escapeRegExp from 'escape-regexp';
 
+// Ensures '-loader' suffix for loaders in config for webpack compatibility
+const ensureLoadersSuffix = loadersArray => {
+  const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
+  const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
+  return loadersArray.map(loader => {
+    if (!loaderSuffixRegExp.test(loader)) {
+      return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);
+    }
+    return loader;
+  });
+};
+
 /**
  * Injects 'resolve-url-loader' and 'sourceMap' param for 'sass-loader'
  *
@@ -15,18 +27,6 @@ Specify your loaders as an array.
 Default is ['style', 'css', 'sass']
     `);
   }
-
-  // Enforce -loader suffix for loaders in config for webpack compatibility
-  const ensureLoadersSuffix = loadersArray => {
-    const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
-    const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
-    return loadersArray.map(loader => {
-      if (!loaderSuffixRegExp.test(loader)) {
-        return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);
-      }
-      return loader;
-    });
-  };
 
   const loadersWithSuffix = ensureLoadersSuffix(loaders);
 

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -28,7 +28,7 @@ Default is ['style', 'css', 'sass']
 
 
   const sassLoaderRegExp = getLoaderRegExp('sass');
-  const sassLoader = (
+  let sassLoader = (
     loaders.find(loader => sassLoaderRegExp.test(loader))
   );
   const sassLoaderIndex = loaders.indexOf(sassLoader);
@@ -42,6 +42,11 @@ Default is ['style', 'css', 'sass']
     }
 
     const sassLoaderQuery = sassLoader.split('?')[1];
+
+    // Enforce '-loader' suffix to support older webpack versions
+    if (!sassLoader.startsWith('sass-loader')) {
+      sassLoader = `sass-loader${sassLoaderQuery}`;
+    }
 
     // We need to check if user's loader already contains sourceMap param
     // And if it's not there - inject it

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -68,7 +68,7 @@ Default is ['style', 'css', 'sass']
     );
 
     if (!resolveUrlLoader) {
-      loaders.splice(sassLoaderIndex, 0, 'resolve-url');
+      loaders.splice(sassLoaderIndex, 0, 'resolve-url-loader');
     }
   }
 

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -17,8 +17,8 @@ Default is ['style', 'css', 'sass']
   }
 
   // Enforce -loader suffix for loaders in config for webpack compatibility
-  const loaderSuffixRegExp = new RegExp('^style-loader.*|^css-loader.*|^sass-loader.*$');
-  const suffixReplaceRegExp = new RegExp('^(style)|^(css)|^(sass)');
+  const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
+  const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
   const loadersWithSuffix = loaders.map(loader => {
     if (!loaderSuffixRegExp.test(loader)) {
       return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -17,14 +17,18 @@ Default is ['style', 'css', 'sass']
   }
 
   // Enforce -loader suffix for loaders in config for webpack compatibility
-  const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
-  const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
-  const loadersWithSuffix = loaders.map(loader => {
-    if (!loaderSuffixRegExp.test(loader)) {
-      return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);
-    }
-    return loader;
-  });
+  const ensureLoadersSuffix = loadersArray => {
+    const loaderSuffixRegExp = new RegExp('^style-loader.*$|^css-loader.*$|^sass-loader.*$|^resolve-url-loader.*$');
+    const suffixReplaceRegExp = new RegExp('^style|^css|^sass|^resolve-url');
+    return loadersArray.map(loader => {
+      if (!loaderSuffixRegExp.test(loader)) {
+        return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);
+      }
+      return loader;
+    });
+  };
+
+  const loadersWithSuffix = ensureLoadersSuffix(loaders);
 
   if (disableSassSourceMap && disableResolveUrlLoader) {
     return loadersWithSuffix;

--- a/src/utils/processStyleLoaders.js
+++ b/src/utils/processStyleLoaders.js
@@ -16,8 +16,18 @@ Default is ['style', 'css', 'sass']
     `);
   }
 
+  // Enforce -loader suffix for loaders in config for webpack compatibility
+  const loaderSuffixRegExp = new RegExp('^style-loader.*|^css-loader.*|^sass-loader.*$');
+  const suffixReplaceRegExp = new RegExp('^(style)|^(css)|^(sass)');
+  const loadersWithSuffix = loaders.map(loader => {
+    if (!loaderSuffixRegExp.test(loader)) {
+      return loader.replace(suffixReplaceRegExp, match => `${match}-loader`);
+    }
+    return loader;
+  });
+
   if (disableSassSourceMap && disableResolveUrlLoader) {
-    return loaders;
+    return loadersWithSuffix;
   }
 
   // We need to match user loaders in different formats:
@@ -28,10 +38,10 @@ Default is ['style', 'css', 'sass']
 
 
   const sassLoaderRegExp = getLoaderRegExp('sass');
-  let sassLoader = (
-    loaders.find(loader => sassLoaderRegExp.test(loader))
+  const sassLoader = (
+    loadersWithSuffix.find(loader => sassLoaderRegExp.test(loader))
   );
-  const sassLoaderIndex = loaders.indexOf(sassLoader);
+  const sassLoaderIndex = loadersWithSuffix.indexOf(sassLoader);
 
   if (!disableSassSourceMap) {
     if (!sassLoader) {
@@ -42,11 +52,6 @@ Default is ['style', 'css', 'sass']
     }
 
     const sassLoaderQuery = sassLoader.split('?')[1];
-
-    // Enforce '-loader' suffix to support older webpack versions
-    if (!sassLoader.startsWith('sass-loader')) {
-      sassLoader = `sass-loader${sassLoaderQuery}`;
-    }
 
     // We need to check if user's loader already contains sourceMap param
     // And if it's not there - inject it
@@ -63,19 +68,19 @@ Default is ['style', 'css', 'sass']
 
 
     // eslint-disable-next-line no-param-reassign
-    loaders[sassLoaderIndex] = sassLoaderWithSourceMap;
+    loadersWithSuffix[sassLoaderIndex] = sassLoaderWithSourceMap;
   }
 
   if (!disableResolveUrlLoader) {
     const resolveUrlLoaderRegExp = getLoaderRegExp('resolve-url');
     const resolveUrlLoader = (
-      loaders.find(loader => resolveUrlLoaderRegExp.test(loader))
+      loadersWithSuffix.find(loader => resolveUrlLoaderRegExp.test(loader))
     );
 
     if (!resolveUrlLoader) {
-      loaders.splice(sassLoaderIndex, 0, 'resolve-url-loader');
+      loadersWithSuffix.splice(sassLoaderIndex, 0, 'resolve-url-loader');
     }
   }
 
-  return loaders;
+  return loadersWithSuffix;
 }


### PR DESCRIPTION
Summary:
-----

The latest build of Webpack (v2.1.0-beta.26) requires loaders be explicitly stated with the `-loader` suffix, thus causing bootstrap-loader to no longer be compatible due to use of shorthand loader names. 

This PR fixes #201. 

Fix Proposed:
-----

This PR handles both cases, with or without `-loader`, to keep compatibility with old webpack users that omit the `-loader` suffix. To do so, I'm proposing the following changes:

- [x] Style loaders coming from `.bootstraprc` are checked for a `-loader` suffix using regex to find for compatible style loaders.
- [x] If the style loader coming from `.bootstraprc` is missing the `-loader` suffix, it replaces the short name with the name + `-loader`. Otherwise, it returns the original loader name if it passes the suffix test.
- [x] For `buildExtractStyleLoaders`, the fallback loader now comes with the `-loader` suffix. Kudos to @silveryiris for this original solution. see https://github.com/shakacode/bootstrap-loader/issues/201#issue-189030570

Test Plan:
----

`buildExtractStylesLoader.test.js` and `processStyleLoaders.test.js` have both been updated to reflect these new changes and test correctly for the new `-loader` suffix. This should pass the requirement in Webpack v2.1.0-beta.26. 

Some additional configuration work will be required to bring the examples up to par with beta.26, however to keep the scope of this PR controlled to the functionality of `-loader` suffix handling, that work is not included in this PR. I can follow up with another PR for proper beta.26 configuration for the examples.

---
cc: @justin808

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/205)
<!-- Reviewable:end -->
