### PR TITLE
Add postcss to webpack -loader suffix note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Default: `[ 'style-loader', 'css-loader', 'sass-loader' ]`
 Array of webpack loaders. `sass-loader` is required, order matters. In most cases the style loader should definitely go first and the sass loader should be last.
 
 Note: Beginning with Webpack v2.1.0-beta.26, the '-loader' suffix is required for all loaders.
-To maintain compatibility with older versions, all accepted style loaders (style, css, sass, resolve-url) are automatically appended with '-loader'.
+To maintain compatibility with older versions, all accepted style loaders (style, css, postcss, sass, resolve-url) are automatically appended with '-loader'.
 It is recommended that you explicitly state the '-loader' suffix for every webpack loader in `styleLoaders` to ensure compatibility in the long term.
 
 ```yaml


### PR DESCRIPTION
Summary:

This PR adds `postcss` to the list of style loader types automatically ensured a `-loader` suffix in the README. 

Simple update to the README on top of #205 to add this missing note, since `postcss` support was added to the `ensureLoadersSuffix` function later on after I had run through the README initially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/209)
<!-- Reviewable:end -->
