### PR TITLE
createUserImport should pass an absolute path to webpack.addDependency

### DIFF
--- a/node_package/tests/utils/createUserImport.test.js
+++ b/node_package/tests/utils/createUserImport.test.js
@@ -11,6 +11,6 @@ test('createUserImport runs as expected', (assert) => {
   };
 
   assert.equals(createUserImport('/module', webpack), '@import "../../module";');
-  assert.deepEquals(webpack.dependencies, ['../../module']);
+  assert.deepEquals(webpack.dependencies, ['/module']);
   assert.end();
 });

--- a/src/utils/createUserImport.js
+++ b/src/utils/createUserImport.js
@@ -9,6 +9,6 @@ import path from 'path';
  */
 export default function(module, webpack) {
   const userModule = path.relative(webpack.context, module);
-  webpack.addDependency(userModule);
+  webpack.addDependency(module);
   return `@import "${userModule}";`;
 }


### PR DESCRIPTION
webpack expects an absolute path.

Fixes #211 .

I updated the relevant test as well and `npm run test` succeeds, are there any other issues?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/212)
<!-- Reviewable:end -->
