### PR TITLE
Allow styleLoaders to depends to env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. Items under
 
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
+## [2.0.0.beta.17] - 2016-12-04
+##### Added
+- Allow `styleLoaders` to depend on the environment variable 'NODE_PATH' [#222](https://github.com/shakacode/bootstrap-loader/pull/222) by [bertho-zero](https://github.com/bertho-zero).
+
 ## [2.0.0.beta.16] - 2016-11-23
 ##### Fixed
 - Improved webpack performance. createUserImport should pass an absolute path to webpack.addDependency. [#212](https://github.com/shakacode/bootstrap-loader/pull/212) by [stephanwilliams](https://github.com/stephanwilliams).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [2.0.0.beta.17] - 2016-12-04
 ##### Added
-- Allow `styleLoaders` to depend on the environment variable 'NODE_PATH' [#222](https://github.com/shakacode/bootstrap-loader/pull/222) by [bertho-zero](https://github.com/bertho-zero).
+- Allow `styleLoaders` to depend on the environment variable `NODE_ENV` [#222](https://github.com/shakacode/bootstrap-loader/pull/222) by [bertho-zero](https://github.com/bertho-zero).
 
 ## [2.0.0.beta.16] - 2016-11-23
 ##### Fixed
@@ -79,7 +79,8 @@ Changes from v1.1.1 to 2.0.0.beta.2
 
 ## [1.0.8]
 
-[Unreleased]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.16...master
+[Unreleased]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.17...master
+[2.0.0.beta.17]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.16...2.0.0-beta.17
 [2.0.0.beta.16]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.15...2.0.0-beta.16
 [2.0.0.beta.15]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.14...2.0.0-beta.15
 [2.0.0.beta.14]: https://github.com/shakacode/bootstrap-loader/compare/2.0.0-beta.13...2.0.0-beta.14

--- a/README.md
+++ b/README.md
@@ -223,8 +223,10 @@ styleLoaders:
 
 # You can apply loader params here:
   - sass-loader?outputStyle=expanded
+```
 
-# Different settings for different environments can be used,
+Different settings for different environments can be used.
+```yaml
 # It depends on value of NODE_ENV environment variable
 env:
   development:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ styleLoaders:
 
 # You can apply loader params here:
   - sass-loader?outputStyle=expanded
+
+# Different settings for different environments can be used,
+# It depends on value of NODE_ENV environment variable
+env:
+  development:
+    styleLoaders:
+      - style-loader
+      - css-loader
+      - resolve-url-loader
+      - sass-loader
+  production:
+    styleLoaders:
+      - style-loader
+      - css-loader
+      - sass-loader
 ```
 
 #### `extractStyles`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-loader",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "Boostrap for Webpack",
   "main": "loader.js",
   "scripts": {

--- a/src/bootstrap.config.js
+++ b/src/bootstrap.config.js
@@ -101,7 +101,7 @@ export default function createConfig({
       appStyles: defaultConfig.appStyles,
       useCustomIconFontPath: defaultConfig.useCustomIconFontPath,
       extractStyles: extractStyles || getEnvProp('extractStyles', defaultConfig),
-      styleLoaders: getEnvProp('styleLoaders', defaultConfig) || defaultConfig.styleLoaders,
+      styleLoaders: getEnvProp('styleLoaders', defaultConfig),
       styles: selectModules(defaultConfig.styles),
       scripts: selectModules(defaultConfig.scripts),
       configFilePath,

--- a/src/bootstrap.config.js
+++ b/src/bootstrap.config.js
@@ -135,7 +135,7 @@ export default function createConfig({
     useFlexbox: userConfig.useFlexbox,
     useCustomIconFontPath: userConfig.useCustomIconFontPath,
     extractStyles: extractStyles || getEnvProp('extractStyles', userConfig),
-    styleLoaders: userConfig.styleLoaders,
+    styleLoaders: getEnvProp('styleLoaders', userConfig),
     styles: selectUserModules(userConfig.styles, defaultConfig.styles),
     scripts: selectUserModules(userConfig.scripts, defaultConfig.scripts),
     configFilePath,

--- a/src/bootstrap.config.js
+++ b/src/bootstrap.config.js
@@ -101,7 +101,7 @@ export default function createConfig({
       appStyles: defaultConfig.appStyles,
       useCustomIconFontPath: defaultConfig.useCustomIconFontPath,
       extractStyles: extractStyles || getEnvProp('extractStyles', defaultConfig),
-      styleLoaders: defaultConfig.styleLoaders,
+      styleLoaders: getEnvProp('styleLoaders', defaultConfig) || defaultConfig.styleLoaders,
       styles: selectModules(defaultConfig.styles),
       scripts: selectModules(defaultConfig.scripts),
       configFilePath,


### PR DESCRIPTION
```
"env": {
    "development": {
      "styleLoaders": ["style-loader", "css-loader", "resolve-url-loader", "sass-loader"],
      "extractStyles": false
    },
    "production": {
      "styleLoaders": ["style-loader", "css-loader", "sass-loader"],
      "extractStyles": true
    }
  }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/222)
<!-- Reviewable:end -->
