### PR TITLE
Fix of the ExtractTextPlugin bug

### DIFF
--- a/src/utils/buildExtractStylesLoader.js
+++ b/src/utils/buildExtractStylesLoader.js
@@ -35,5 +35,10 @@ Error: ${error}
       .map(loader => `${loader}!`)
       .join('')
   );
-  return ExtractTextPlugin.extract({ fallbackLoader, loader: restLoaders });
+  
+  return [
+    ExtractTextPlugin.loader().loader + '?omit&remove',
+    fallbackLoader,
+    restLoaders
+  ].join('!');
 }

--- a/src/utils/buildExtractStylesLoader.js
+++ b/src/utils/buildExtractStylesLoader.js
@@ -35,10 +35,9 @@ Error: ${error}
       .map(loader => `${loader}!`)
       .join('')
   );
-  
   return [
-    ExtractTextPlugin.loader().loader + '?omit&remove',
+    `${ExtractTextPlugin.loader().loader}?omit&remove`,
     fallbackLoader,
-    restLoaders
+    restLoaders,
   ].join('!');
 }


### PR DESCRIPTION
This is a quick fix to get compatibility with the latest `webpack` (2.2.1) and the latest `extract-text-webpack-plugin`. Should fix #238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/249)
<!-- Reviewable:end -->
