### PR TITLE
Fix typo in .bootstraprc-3-example

### DIFF
--- a/examples/basic/.bootstraprc-3-example
+++ b/examples/basic/.bootstraprc-3-example
@@ -40,7 +40,7 @@ preBootstrapCustomizations: ./app/styles/bootstrap/pre-customizations.scss
 # This gets loaded after bootstrap/variables is loaded and before bootstrap is loaded.
 # A good example of this is when you want to override a bootstrap variable to be based
 # on the default value of bootstrap. This is pretty specialized case. Thus, you normally
-# just override bootrap variables in preBootstrapCustomizations so that derived
+# just override bootstrap variables in preBootstrapCustomizations so that derived
 # variables will use your definition.
 #
 # For example, in _variables.scss:


### PR DESCRIPTION
- Fix the spelling of `bootstrap` in .bootstraprc file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/289)
<!-- Reviewable:end -->
