### PR TITLE
add config for Popper for jquery plugin using Bootstrap 4 

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ plugins: [
     "window.jQuery": "jquery",
     Tether: "tether",
     "window.Tether": "tether",
+    Popper: ['popper.js', 'default'],
     Alert: "exports-loader?Alert!bootstrap/js/dist/alert",
     Button: "exports-loader?Button!bootstrap/js/dist/button",
     Carousel: "exports-loader?Carousel!bootstrap/js/dist/carousel",


### PR DESCRIPTION
Console will show "Popover variable not defined" error and Popover.js functionality built in to Bootstrap 4 did not work without first adding this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/336)
<!-- Reviewable:end -->
