### PR TITLE
Remove extract-text-webpack-plugin peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   ],
   "peerDependencies": {
     "css-loader": "*",
-    "extract-text-webpack-plugin": ">=2.1.0",
     "node-sass": "*",
     "resolve-url-loader": "*",
     "sass-loader": "*",


### PR DESCRIPTION
mini-css-extract-plugin is now the recommended CSS loading solution for Webpack 4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/344)
<!-- Reviewable:end -->
