### PR TITLE
Fix ecmaFeatures deprecation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,8 +10,9 @@ globals:
   __DEBUG__: true
   __BOOTSTRAP_CONFIG__: true
 
-ecmaFeatures:
-  restParams: true
+parserOptions:
+  ecmaFeatures:
+    restParams: true
 
 rules:
   prettier/prettier: "error"


### PR DESCRIPTION
According to [official documentation](https://eslint.org/docs/latest/user-guide/configuring/language-options#specifying-parser-options), we should change the syntax of configuring `ecmaFeatures`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/415)
<!-- Reviewable:end -->
