### PR TITLE
Remove type entry in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## [Unreleased]
 *Please add entries here for your pull requests.*
 
+#### Fixed
+- Remove `type` entry from `package.json` introduced in 4.0.3 [PR419](https://github.com/shakacode/bootstrap-loader/pull/419) by [ahangarha](https://github.com/ahangarha).
+
 ## [4.0.3] - 2023-03-03
 #### Fixed
 - Upgraded dependencies to fix vulnerabilities, included loader-utils [PR418](https://github.com/shakacode/bootstrap-loader/pull/418) by [ahangarha](https://github.com/ahangarha).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "4.0.3",
   "description": "Boostrap for Webpack",
   "main": "loader.js",
-  "type": "module",
   "scripts": {
     "test": "babel-tape-runner node_package/tests/**/*.test.js | tap-spec",
     "start": "npm run lint && npm run clean && npm run dev",


### PR DESCRIPTION
### Summary

This PR reverts the bug introduced in #416. Having `type` entry in `package.json` file causes malfunctions in this package.

### Pull Request checklist
- [x] ~Add/update test to cover these changes~ (not needed)
- [x] ~Update documentation~ (not needed)
- [x] Update CHANGELOG file  

### Other Information

We need to have a test to cover such situation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/bootstrap-loader/419)
<!-- Reviewable:end -->
