### PR TITLE
test: fix configuration test failures and quote npm script glob

### DIFF
--- a/node_package/tests/bootstrap.config.test.js
+++ b/node_package/tests/bootstrap.config.test.js
@@ -43,7 +43,7 @@ test('createConfig uses default config if user config is not provided', assert =
     appStyles: undefined,
     useCustomIconFontPath: false,
     extractStyles: false,
-    styleLoaders: ['style', 'css', 'sass'],
+    styleLoaders: ['style-loader', 'css-loader', 'sass-loader'],
     styles: [
       'mixins',
       'normalize',
@@ -106,18 +106,23 @@ test('createConfig uses default config if user config is not provided', assert =
 });
 
 test('createConfig uses user config as expected', assert => {
+  const testConfigsDir = path.resolve(__dirname, './test_configs');
   const expectedResult = {
     appStyles: undefined,
-    bootstrapCustomizations:
-      '/home/ubuntu/workspace/node_package/tests' +
-      'test_configs/path/to/bootstrap/customizations.scss',
+    bootstrapCustomizations: path.resolve(
+      testConfigsDir,
+      './path/to/bootstrap/customizations.scss'
+    ),
     bootstrapVersion: 4,
-    configFilePath: path.resolve(__dirname, './test_configs/test_bootstraprc'),
+    configFilePath: path.resolve(testConfigsDir, './test_bootstraprc'),
     extractStyles: true,
     loglevel: undefined,
-    preBootstrapCustomizations:
-      '/home/ubuntu/workspace/node_package/tests' +
-      'test_configs/path/to/bootstrap/pre-customizations.scss',
+    preBootstrapCustomizations: path.resolve(
+      testConfigsDir,
+      './path/to/bootstrap/pre-customizations.scss'
+    ),
+    disableSassSourceMap: undefined,
+    disableResolveUrlLoader: undefined,
     scripts: [
       'alert',
       'button',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Boostrap for Webpack",
   "main": "loader.js",
   "scripts": {
-    "test": "babel-tape-runner node_package/tests/**/*.test.js | tap-spec",
+    "test": "babel-tape-runner \"node_package/tests/**/*.test.js\" | tap-spec",
     "start": "npm run lint && npm run clean && npm run dev",
     "dev": "babel --watch --out-dir lib src",
     "build": "babel --out-dir lib src",


### PR DESCRIPTION
Fixes two configuration-related tests that were failing due to out-of-date expectation objects and hardcoded remote paths (specifically a `/home/ubuntu/...` prefix). Also quotes the test glob pattern in package.json to prevent incorrect shell expansion so that all tests are correctly run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test expectations to match current configuration output.
  * Improved path handling in tests for more consistent results across environments.
  * Adjusted the test command to handle file-matching patterns more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->